### PR TITLE
feat: add derive command

### DIFF
--- a/cmd/mdschema/commands/derive.go
+++ b/cmd/mdschema/commands/derive.go
@@ -1,0 +1,63 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/jackchuka/mdschema/internal/parser"
+	"github.com/jackchuka/mdschema/internal/schema/infer"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+)
+
+// NewDeriveCmd creates the derive command
+func NewDeriveCmd() *cobra.Command {
+	var outputFile string
+
+	cmd := &cobra.Command{
+		Use:   "derive <markdown-file>",
+		Short: "Infer a schema from an existing Markdown document",
+		Long:  "Analyze a Markdown document and generate a schema that reflects its heading hierarchy.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			markdownPath := args[0]
+			return runDerive(cmd, markdownPath, outputFile)
+		},
+	}
+
+	cmd.Flags().StringVarP(&outputFile, "output", "o", "", "Output file (default: stdout)")
+
+	return cmd
+}
+
+func runDerive(cmd *cobra.Command, markdownPath, outputFile string) error {
+	p := parser.New()
+	doc, err := p.ParseFile(markdownPath)
+	if err != nil {
+		return fmt.Errorf("parsing markdown: %w", err)
+	}
+
+	inferred, err := infer.FromDocument(doc)
+	if err != nil {
+		return fmt.Errorf("inferring schema: %w", err)
+	}
+
+	data, err := yaml.Marshal(inferred)
+	if err != nil {
+		return fmt.Errorf("encoding schema: %w", err)
+	}
+
+	if outputFile != "" {
+		if err := os.WriteFile(outputFile, data, 0o644); err != nil {
+			return fmt.Errorf("writing schema to %s: %w", outputFile, err)
+		}
+		_, _ = fmt.Fprintf(cmd.OutOrStdout(), "✓ Derived schema written to %s\n", outputFile)
+		return nil
+	}
+
+	if _, err := cmd.OutOrStdout().Write(data); err != nil {
+		return fmt.Errorf("writing schema to stdout: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/mdschema/commands/root.go
+++ b/cmd/mdschema/commands/root.go
@@ -29,6 +29,7 @@ using declarative schemas to maintain consistent documentation across projects.`
 	cmd.AddCommand(NewInitCmd())
 	cmd.AddCommand(NewCheckCmd())
 	cmd.AddCommand(NewGenerateCmd())
+	cmd.AddCommand(NewDeriveCmd())
 	cmd.AddCommand(NewVersionCmd())
 
 	return cmd

--- a/internal/schema/infer/infer.go
+++ b/internal/schema/infer/infer.go
@@ -1,0 +1,100 @@
+package infer
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"strings"
+
+	"github.com/jackchuka/mdschema/internal/parser"
+	"github.com/jackchuka/mdschema/internal/schema"
+)
+
+// FromDocument converts a parsed Markdown document into a schema definition.
+func FromDocument(doc *parser.Document) (*schema.Schema, error) {
+	if doc == nil {
+		return nil, fmt.Errorf("document is nil")
+	}
+
+	if doc.Root == nil {
+		return nil, fmt.Errorf("document has no structural information")
+	}
+
+	if len(doc.Root.Children) == 0 {
+		return nil, fmt.Errorf("document has no headings to infer structure")
+	}
+
+	frontMatterEnd, hasFrontMatter := detectFrontMatter(doc.Content)
+
+	structure := make([]schema.StructureElement, 0, len(doc.Root.Children))
+	for _, section := range doc.Root.Children {
+		if hasFrontMatter && section.StartLine <= frontMatterEnd {
+			continue
+		}
+		structure = append(structure, buildElement(section))
+	}
+
+	if len(structure) == 0 {
+		return nil, fmt.Errorf("document has no headings to infer structure")
+	}
+
+	return &schema.Schema{Structure: structure}, nil
+}
+
+func buildElement(section *parser.Section) schema.StructureElement {
+	heading := ""
+	if section.Heading != nil {
+		heading = headingPattern(section.Heading)
+	}
+
+	var children []schema.StructureElement
+	if len(section.Children) > 0 {
+		children = make([]schema.StructureElement, 0, len(section.Children))
+		for _, child := range section.Children {
+			children = append(children, buildElement(child))
+		}
+	}
+
+	return schema.StructureElement{
+		Heading:  heading,
+		Children: children,
+	}
+}
+
+func headingPattern(h *parser.Heading) string {
+	if h == nil {
+		return ""
+	}
+
+	prefix := strings.Repeat("#", h.Level)
+	text := strings.TrimSpace(h.Text)
+	if text == "" {
+		return prefix
+	}
+	return fmt.Sprintf("%s %s", prefix, text)
+}
+
+func detectFrontMatter(content []byte) (endLine int, ok bool) {
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	lineNum := 0
+
+	if !scanner.Scan() {
+		return 0, false
+	}
+	lineNum++
+	line := scanner.Text()
+	line = strings.TrimPrefix(line, "\ufeff")
+	if strings.TrimSpace(line) != "---" {
+		return 0, false
+	}
+
+	for scanner.Scan() {
+		lineNum++
+		trimmed := strings.TrimSpace(scanner.Text())
+		if trimmed == "---" || trimmed == "..." {
+			return lineNum, true
+		}
+	}
+
+	return 0, false
+}

--- a/internal/schema/infer/infer_test.go
+++ b/internal/schema/infer/infer_test.go
@@ -1,0 +1,121 @@
+package infer
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/jackchuka/mdschema/internal/parser"
+	"github.com/jackchuka/mdschema/internal/schema"
+)
+
+func TestFromDocumentBuildsStructure(t *testing.T) {
+	content := `# Project Title
+
+Intro text
+
+## Overview
+Context here
+
+### Background
+Details
+
+## Usage
+
+### Install
+Steps
+
+### Run
+Steps
+`
+
+	p := parser.New()
+	doc, err := p.Parse("test.md", []byte(content))
+	if err != nil {
+		t.Fatalf("parse markdown: %v", err)
+	}
+
+	got, err := FromDocument(doc)
+	if err != nil {
+		t.Fatalf("FromDocument returned error: %v", err)
+	}
+
+	want := &schema.Schema{
+		Structure: []schema.StructureElement{
+			{
+				Heading: "# Project Title",
+				Children: []schema.StructureElement{
+					{
+						Heading: "## Overview",
+						Children: []schema.StructureElement{
+							{Heading: "### Background"},
+						},
+					},
+					{
+						Heading: "## Usage",
+						Children: []schema.StructureElement{
+							{Heading: "### Install"},
+							{Heading: "### Run"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FromDocument mismatch\nwant: %#v\n got: %#v", want, got)
+	}
+}
+
+func TestFromDocumentRequiresHeadings(t *testing.T) {
+	content := "plain text with no headings"
+
+	p := parser.New()
+	doc, err := p.Parse("test.md", []byte(content))
+	if err != nil {
+		t.Fatalf("parse markdown: %v", err)
+	}
+
+	if _, err := FromDocument(doc); err == nil {
+		t.Fatal("expected error when document has no headings, got nil")
+	}
+}
+
+func TestFromDocumentSkipsFrontMatter(t *testing.T) {
+	content := `---
+title: "Example"
+author: "Doc Writer"
+---
+
+# First
+
+Body
+
+## Child
+
+More
+`
+
+	p := parser.New()
+	doc, err := p.Parse("test.md", []byte(content))
+	if err != nil {
+		t.Fatalf("parse markdown: %v", err)
+	}
+
+	got, err := FromDocument(doc)
+	if err != nil {
+		t.Fatalf("FromDocument returned error: %v", err)
+	}
+
+	if len(got.Structure) == 0 {
+		t.Fatalf("expected structure elements, got none")
+	}
+
+	if got.Structure[0].Heading != "# First" {
+		t.Fatalf("expected first heading '# First', got %q", got.Structure[0].Heading)
+	}
+
+	if len(got.Structure[0].Children) != 1 || got.Structure[0].Children[0].Heading != "## Child" {
+		t.Fatalf("expected child heading '## Child', got %#v", got.Structure[0].Children)
+	}
+}


### PR DESCRIPTION
This pull request introduces a new "derive" command to the CLI, allowing users to infer a schema from an existing Markdown document. The schema inference logic is implemented in a new package, and comprehensive tests are included to ensure correct behavior, including handling of front matter and heading hierarchies.

**New CLI command:**

- Added a `derive` subcommand (`NewDeriveCmd`) to the CLI, which analyzes a Markdown file and generates a schema reflecting its heading hierarchy. The command supports outputting the schema to a file or stdout. [[1]](diffhunk://#diff-4d429e2b504b08a21efe11137cf696dcbaa07c4ed4698a4b8726368836b5ba3eR1-R63) [[2]](diffhunk://#diff-bbdd956ad7bb422d85f1bb44c38546761ae401d2dfa2fddc715c14b51a5f108fR32)

**Schema inference logic:**

- Implemented the `infer` package with a `FromDocument` function that builds a schema from a parsed Markdown document, correctly handling heading levels and skipping front matter.

**Testing:**

- Added tests for the inference logic, covering correct schema construction, error handling for documents without headings, and proper skipping of front matter.