### PR TITLE
fix: generate string literal

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -63,16 +63,5 @@ func (g *Generator) extractHeadingText(pattern string) string {
 		text = strings.TrimSpace(text[1:])
 	}
 
-	// Handle common regex patterns
-	if strings.Contains(text, "[a-zA-Z0-9_\\- ]+") {
-		return "Your Project Title"
-	}
-
-	// If it's a literal heading, return as-is
-	if !strings.ContainsAny(text, "[](){}*+?^$|\\") {
-		return text
-	}
-
-	// For complex patterns, provide a placeholder
-	return "Section Title"
+	return text
 }

--- a/internal/schema/infer/infer_test.go
+++ b/internal/schema/infer/infer_test.go
@@ -91,7 +91,7 @@ author: "Doc Writer"
 
 Body
 
-## Child
+## Child (Optional)
 
 More
 `
@@ -115,7 +115,7 @@ More
 		t.Fatalf("expected first heading '# First', got %q", got.Structure[0].Heading)
 	}
 
-	if len(got.Structure[0].Children) != 1 || got.Structure[0].Children[0].Heading != "## Child" {
-		t.Fatalf("expected child heading '## Child', got %#v", got.Structure[0].Children)
+	if len(got.Structure[0].Children) != 1 || got.Structure[0].Children[0].Heading != "## Child (Optional)" {
+		t.Fatalf("expected child heading '## Child (Optional)', got %#v", got.Structure[0].Children)
 	}
 }


### PR DESCRIPTION
This pull request makes a small adjustment to how heading text is extracted and updates a related test to match the new behavior. The main change is simplifying the logic for extracting heading text, which now returns the heading as-is instead of substituting placeholders for certain patterns. The test assertions are updated accordingly.

- Heading extraction logic:
  * Simplified `extractHeadingText` in `generator.go` to always return the literal heading text, removing special handling for regex patterns and placeholders.

- Test updates:
  * Updated test content and assertions in `infer_test.go` to expect the new heading format, specifically recognizing "## Child (Optional)" instead of "## Child". [[1]](diffhunk://#diff-84cc131200a15ed593a23f7b922d297b0d5e8b7c4c5a71a3f4df87c9666bc18cL94-R94) [[2]](diffhunk://#diff-84cc131200a15ed593a23f7b922d297b0d5e8b7c4c5a71a3f4df87c9666bc18cL118-R119)