### PR TITLE
chore: bump Go version to 1.26.5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jackchuka/mdschema
 
-go 1.26.1
+go 1.26.5
 
 require (
 	github.com/expr-lang/expr v1.17.8


### PR DESCRIPTION
## Version bump

Go version updated from **1.26.1** to **1.26.5**.

## Release notes

Go 1.26.5 (2026-07-07) includes security fixes for:
- crypto/tls
- os

## Verification

- `go mod tidy` completes cleanly with no changes
- `go test ./...` passes on macOS/arm64