### PR TITLE
feat(frontmatter): add enum validation for field values

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,10 +370,24 @@ frontmatter:
     - { name: "draft", optional: true, type: boolean }
     - { name: "version", optional: true, type: number }
     - { name: "repo", optional: true, format: url }
+    - { name: "status", enum: [draft, published, archived] } # restrict to listed values
 ```
 
 **Field types:** `string`, `number`, `boolean`, `array`, `date`, `object`
 **Field formats:** `date` (YYYY-MM-DD), `email`, `url`
+
+##### Enum Values
+
+Use `enum` to restrict a field to a fixed set of values. For `array` fields,
+every element must be one of the listed values:
+
+```yaml
+frontmatter:
+  fields:
+    - { name: "status", enum: [draft, published, archived] }
+    - { name: "priority", type: number, enum: [1, 2, 3] }
+    - { name: "tags", type: array, enum: [go, cli, markdown] }
+```
 
 ##### Nested Frontmatter Keys
 

--- a/examples/blog-post.md
+++ b/examples/blog-post.md
@@ -1,0 +1,35 @@
+---
+title: Validating Markdown with mdschema
+date: 2026-08-02
+status: published
+priority: 2
+tags:
+  - go
+  - markdown
+author:
+  name: example-author
+  email: author@example.com
+  homepage: https://example.com
+---
+
+# Validating Markdown with mdschema
+
+## Introduction
+
+This post shows how mdschema keeps blog posts consistent. The frontmatter
+above is validated against the schema: `status` must be one of `draft`,
+`published`, or `archived`, and every entry in `tags` must come from the
+allowed list.
+
+## Content
+
+Change `status` to a value like `pending` and run the check again to see an
+enum violation:
+
+```bash
+mdschema check examples/blog-post.md --schema examples/blog-post.mdschema.yml
+```
+
+## Conclusion
+
+Frontmatter validation catches typos in metadata before they reach your site.

--- a/examples/blog-post.mdschema.yml
+++ b/examples/blog-post.mdschema.yml
@@ -26,8 +26,6 @@ structure:
       pattern: "# .*"
     children:
       - heading: "## Introduction"
-        forbidden_text:
-          - "TODO"
       - heading: "## Content"
         allow_additional: true
       - heading: "## Conclusion"

--- a/examples/blog-post.mdschema.yml
+++ b/examples/blog-post.mdschema.yml
@@ -1,0 +1,34 @@
+# yaml-language-server: $schema=../schema.json
+#
+# Example schema for blog posts with frontmatter validation
+# Demonstrates required/optional fields, types, formats, nested keys,
+# and enum-restricted values.
+
+frontmatter:
+  # optional: false is default, meaning frontmatter is required
+  fields:
+    - { name: "title", type: string } # required by default
+    - { name: "date", type: date, format: date }
+    - { name: "status", enum: [draft, published, archived] } # value must be one of these
+    - { name: "priority", optional: true, type: number, enum: [1, 2, 3] }
+    - { name: "tags", optional: true, type: array, enum: [go, cli, markdown, tutorial] } # each element checked
+    - { name: "author", type: object }
+    - { name: "author.name" } # nested key via dot-notation
+    - { name: "author.email", optional: true, format: email }
+    - { name: "author.homepage", optional: true, format: url }
+
+heading_rules:
+  no_skip_levels: true
+  max_depth: 3
+
+structure:
+  - heading:
+      pattern: "# .*"
+    children:
+      - heading: "## Introduction"
+        forbidden_text:
+          - "TODO"
+      - heading: "## Content"
+        allow_additional: true
+      - heading: "## Conclusion"
+        optional: true

--- a/internal/rules/frontmatter.go
+++ b/internal/rules/frontmatter.go
@@ -86,6 +86,14 @@ func (r *FrontmatterRule) ValidateWithContext(ctx *vast.Context) []Violation {
 					NewViolation(r.Name(), err, 1, 1))
 			}
 		}
+
+		// Validate allowed values if specified
+		if len(field.Enum) > 0 {
+			if err := r.validateFieldEnum(field.Name, value, field.Enum); err != "" {
+				violations = append(violations,
+					NewViolation(r.Name(), err, 1, 1))
+			}
+		}
 	}
 
 	return violations
@@ -227,6 +235,72 @@ func (r *FrontmatterRule) validateFieldFormat(name string, value any, format sch
 	return ""
 }
 
+// validateFieldEnum checks if a field value is one of the allowed values.
+// For array values, every element is checked against the allowed values.
+func (r *FrontmatterRule) validateFieldEnum(name string, value any, allowed []any) string {
+	if arr, ok := value.([]any); ok {
+		for _, elem := range arr {
+			if !enumContains(allowed, elem) {
+				return fmt.Sprintf("Frontmatter field '%s' contains %s, allowed values: %s",
+					name, formatEnumValue(elem), formatEnumList(allowed))
+			}
+		}
+		return ""
+	}
+	if !enumContains(allowed, value) {
+		return fmt.Sprintf("Frontmatter field '%s' has value %s, allowed values: %s",
+			name, formatEnumValue(value), formatEnumList(allowed))
+	}
+	return ""
+}
+
+func enumContains(allowed []any, value any) bool {
+	for _, a := range allowed {
+		if enumEqual(a, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// enumEqual compares an allowed value against a frontmatter value, treating
+// numeric types (int, int64, float64) as interchangeable since YAML parsing
+// may produce any of them.
+func enumEqual(a, b any) bool {
+	if af, aok := toFloat(a); aok {
+		bf, bok := toFloat(b)
+		return bok && af == bf
+	}
+	return a == b
+}
+
+func toFloat(v any) (float64, bool) {
+	switch n := v.(type) {
+	case int:
+		return float64(n), true
+	case int64:
+		return float64(n), true
+	case float64:
+		return n, true
+	}
+	return 0, false
+}
+
+func formatEnumValue(v any) string {
+	if s, ok := v.(string); ok {
+		return fmt.Sprintf("%q", s)
+	}
+	return fmt.Sprintf("%v", v)
+}
+
+func formatEnumList(allowed []any) string {
+	parts := make([]string, len(allowed))
+	for i, a := range allowed {
+		parts[i] = formatEnumValue(a)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
 // isValidDateFormat checks if a string is in YYYY-MM-DD format
 func isValidDateFormat(s string) bool {
 	dateRegex := regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
@@ -334,6 +408,14 @@ func hasRequiredDescendant(n *fmTreeNode) bool {
 
 // getPlaceholder returns an appropriate placeholder value based on field type/format
 func (r *FrontmatterRule) getPlaceholder(field schema.FrontmatterField) string {
+	// An enum pins the value down to a known set, so use its first entry
+	if len(field.Enum) > 0 {
+		if field.Type == schema.FieldTypeArray {
+			return "[" + formatEnumValue(field.Enum[0]) + "]"
+		}
+		return formatEnumValue(field.Enum[0])
+	}
+
 	// Check format first as it's more specific
 	switch field.Format {
 	case schema.FieldFormatDate:

--- a/internal/rules/frontmatter_test.go
+++ b/internal/rules/frontmatter_test.go
@@ -312,6 +312,120 @@ func TestFrontmatterRuleOptionalField(t *testing.T) {
 	}
 }
 
+func TestFrontmatterRuleEnum(t *testing.T) {
+	tests := []struct {
+		name           string
+		content        string
+		field          schema.FrontmatterField
+		wantViolations int
+		wantMessage    string
+	}{
+		{
+			name:    "string value in enum",
+			content: "---\nstatus: draft\n---\n\n# Title\n",
+			field:   schema.FrontmatterField{Name: "status", Enum: []any{"draft", "published", "archived"}},
+		},
+		{
+			name:           "string value not in enum",
+			content:        "---\nstatus: pending\n---\n\n# Title\n",
+			field:          schema.FrontmatterField{Name: "status", Enum: []any{"draft", "published", "archived"}},
+			wantViolations: 1,
+			wantMessage:    `Frontmatter field 'status' has value "pending", allowed values: ["draft", "published", "archived"]`,
+		},
+		{
+			name:    "number value in enum",
+			content: "---\npriority: 2\n---\n\n# Title\n",
+			field:   schema.FrontmatterField{Name: "priority", Enum: []any{1, 2, 3}},
+		},
+		{
+			name:           "number value not in enum",
+			content:        "---\npriority: 5\n---\n\n# Title\n",
+			field:          schema.FrontmatterField{Name: "priority", Enum: []any{1, 2, 3}},
+			wantViolations: 1,
+		},
+		{
+			name:    "array with all elements in enum",
+			content: "---\ntags:\n  - go\n  - cli\n---\n\n# Title\n",
+			field:   schema.FrontmatterField{Name: "tags", Type: schema.FieldTypeArray, Enum: []any{"go", "cli", "markdown"}},
+		},
+		{
+			name:           "array with element not in enum",
+			content:        "---\ntags:\n  - go\n  - rust\n---\n\n# Title\n",
+			field:          schema.FrontmatterField{Name: "tags", Type: schema.FieldTypeArray, Enum: []any{"go", "cli", "markdown"}},
+			wantViolations: 1,
+			wantMessage:    `Frontmatter field 'tags' contains "rust", allowed values: ["go", "cli", "markdown"]`,
+		},
+		{
+			name:    "missing optional field skips enum",
+			content: "---\ntitle: Test\n---\n\n# Title\n",
+			field:   schema.FrontmatterField{Name: "status", Optional: true, Enum: []any{"draft", "published"}},
+		},
+		{
+			name:    "nested field in enum",
+			content: "---\nmetadata:\n  visibility: public\n---\n\n# Title\n",
+			field:   schema.FrontmatterField{Name: "metadata.visibility", Enum: []any{"public", "private"}},
+		},
+		{
+			name:           "nested field not in enum",
+			content:        "---\nmetadata:\n  visibility: internal\n---\n\n# Title\n",
+			field:          schema.FrontmatterField{Name: "metadata.visibility", Enum: []any{"public", "private"}},
+			wantViolations: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := parser.New()
+			doc, err := p.Parse("test.md", []byte(tt.content))
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+
+			s := &schema.Schema{
+				Frontmatter: &schema.FrontmatterConfig{
+					Fields: []schema.FrontmatterField{tt.field},
+				},
+			}
+
+			ctx := vast.NewContext(doc, s, "")
+			rule := NewFrontmatterRule()
+			violations := rule.ValidateWithContext(ctx)
+
+			if len(violations) != tt.wantViolations {
+				t.Fatalf("Got %d violations, want %d: %v", len(violations), tt.wantViolations, violations)
+			}
+			if tt.wantMessage != "" && violations[0].Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", violations[0].Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+func TestFrontmatterRuleGenerateEnumPlaceholder(t *testing.T) {
+	rule := NewFrontmatterRule()
+	var builder strings.Builder
+
+	s := &schema.Schema{
+		Frontmatter: &schema.FrontmatterConfig{
+			Fields: []schema.FrontmatterField{
+				{Name: "status", Enum: []any{"draft", "published"}},
+				{Name: "tags", Type: schema.FieldTypeArray, Enum: []any{"go", "cli"}},
+			},
+		},
+	}
+	if !rule.Generate(&builder, s) {
+		t.Fatal("Generate() should return true when frontmatter config exists")
+	}
+
+	output := builder.String()
+	if !strings.Contains(output, `status: "draft"`) {
+		t.Errorf("Output should use first enum value as placeholder, got:\n%s", output)
+	}
+	if !strings.Contains(output, `tags: ["go"]`) {
+		t.Errorf("Output should use first enum value wrapped in array, got:\n%s", output)
+	}
+}
+
 func TestFrontmatterRuleGenerateDocumentPreamble(t *testing.T) {
 	rule := NewFrontmatterRule()
 	var builder strings.Builder

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -519,4 +519,8 @@ type FrontmatterField struct {
 
 	// Format specifies format validation (use FieldFormat* constants)
 	Format FieldFormat `yaml:"format,omitempty" json:"format,omitempty" lc:"date, email, or url"`
+
+	// Enum restricts the field value to one of the listed values. For array
+	// fields, every element must be one of the listed values.
+	Enum []any `yaml:"enum,omitempty" json:"enum,omitempty" lc:"allowed values (for arrays, applies to each element)"`
 }

--- a/schema.json
+++ b/schema.json
@@ -90,6 +90,11 @@
         "format": {
           "$ref": "#/$defs/FieldFormat",
           "description": "Date, email, or url"
+        },
+        "enum": {
+          "items": true,
+          "type": "array",
+          "description": "Allowed values (for arrays, applies to each element)"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
Closes #79

## Summary

Adds an `enum` option to frontmatter field definitions, restricting a field to a fixed set of allowed values:

```yaml
frontmatter:
  fields:
    - { name: "status", enum: [draft, published, archived] }
    - { name: "priority", type: number, enum: [1, 2, 3] }
    - { name: "tags", type: array, enum: [go, cli, markdown] }
```

## Changes

- `internal/schema/schema.go` — new `Enum []any` field on `FrontmatterField` (flows automatically into unknown-key warnings and JSON Schema generation)
- `internal/rules/frontmatter.go` — enum validation: scalar values must match one of the allowed values; for arrays, every element is checked. Numeric comparison works across `int`/`int64`/`float64` since YAML parsing may produce any of them. Violation messages list the offending value and the allowed set.
- Template generation (`mdschema generate`) uses the first enum value as the placeholder (wrapped in `[...]` for array fields)
- `schema.json` regenerated via `mdschema schema -o schema.json`
- README: documented `enum` with examples
- Tests: table-driven coverage for scalars, numbers, arrays, nested (dot-notation) keys, and optional-field skipping; generator placeholder test
- `examples/blog-post.md` + `examples/blog-post.mdschema.yml` — new example demonstrating frontmatter validation (types, formats, nested keys, enum)

## Test plan

- `go test -race ./...` — all green
- `golangci-lint run` — 0 issues
- `schema.json` in sync with generator output
- `mdschema check README.md --schema examples/README.mdschema.yml` — no violations
- `mdschema generate` → `check` roundtrip on the enum example schema — clean; mutating `status`/`tags` to out-of-enum values produces the expected violations
