### PR TITLE
fix(frontmatter): correct enum matching edge cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,16 +378,22 @@ frontmatter:
 
 ##### Enum Values
 
-Use `enum` to restrict a field to a fixed set of values. For `array` fields,
-every element must be one of the listed values:
+Use `enum` to restrict a field to a fixed set of values. Declare `type: array`
+to check each element of a list instead of the list as a whole:
 
 ```yaml
 frontmatter:
   fields:
     - { name: "status", enum: [draft, published, archived] }
     - { name: "priority", type: number, enum: [1, 2, 3] }
-    - { name: "tags", type: array, enum: [go, cli, markdown] }
+    - { name: "released", type: date, enum: [2024-01-01, 2024-07-01] }
+    - { name: "tags", type: array, enum: [go, cli, markdown] } # every element must be listed
 ```
+
+Enum entries are compared against the declared `type` (or the type implied by
+`format`), so a mismatch such as `{ type: number, enum: [low, high] }` or
+`{ format: email, enum: [1, 2] }` — which no value could ever satisfy — is
+reported as a schema warning when the schema is loaded.
 
 ##### Nested Frontmatter Keys
 

--- a/internal/rules/frontmatter.go
+++ b/internal/rules/frontmatter.go
@@ -2,12 +2,17 @@ package rules
 
 import (
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/jackchuka/mdschema/internal/schema"
 	"github.com/jackchuka/mdschema/internal/vast"
 )
+
+// dateLayout is the only date form mdschema validates (see FieldFormatDate).
+const dateLayout = "2006-01-02"
 
 // FrontmatterRule validates YAML frontmatter at the start of documents
 type FrontmatterRule struct {
@@ -72,10 +77,12 @@ func (r *FrontmatterRule) ValidateWithContext(ctx *vast.Context) []Violation {
 		}
 
 		// Validate field type if specified
+		wellFormed := true
 		if field.Type != "" {
 			if err := r.validateFieldType(field.Name, value, field.Type); err != "" {
 				violations = append(violations,
 					NewViolation(r.Name(), err, 1, 1))
+				wellFormed = false
 			}
 		}
 
@@ -84,12 +91,16 @@ func (r *FrontmatterRule) ValidateWithContext(ctx *vast.Context) []Violation {
 			if err := r.validateFieldFormat(field.Name, value, field.Format); err != "" {
 				violations = append(violations,
 					NewViolation(r.Name(), err, 1, 1))
+				wellFormed = false
 			}
 		}
 
-		// Validate allowed values if specified
-		if len(field.Enum) > 0 {
-			if err := r.validateFieldEnum(field.Name, value, field.Enum); err != "" {
+		// Validate allowed values if specified. A value that already failed its
+		// type or format check cannot match any enum entry either, and reporting
+		// both leaves the reader with two violations for one mistake — the
+		// earlier, more specific message stands on its own.
+		if len(field.Enum) > 0 && wellFormed {
+			for _, err := range r.validateFieldEnum(field, value) {
 				violations = append(violations,
 					NewViolation(r.Name(), err, 1, 1))
 			}
@@ -235,23 +246,30 @@ func (r *FrontmatterRule) validateFieldFormat(name string, value any, format sch
 	return ""
 }
 
-// validateFieldEnum checks if a field value is one of the allowed values.
-// For array values, every element is checked against the allowed values.
-func (r *FrontmatterRule) validateFieldEnum(name string, value any, allowed []any) string {
-	if arr, ok := value.([]any); ok {
+// validateFieldEnum checks if a field value is one of the allowed values. For
+// array fields every element is checked, so a document listing several
+// disallowed values reports all of them in a single run.
+func (r *FrontmatterRule) validateFieldEnum(field schema.FrontmatterField, value any) []string {
+	if field.Type == schema.FieldTypeArray {
+		arr, ok := value.([]any)
+		if !ok {
+			// validateFieldType already reports the wrong shape.
+			return nil
+		}
+		var errs []string
 		for _, elem := range arr {
-			if !enumContains(allowed, elem) {
-				return fmt.Sprintf("Frontmatter field '%s' contains %s, allowed values: %s",
-					name, formatEnumValue(elem), formatEnumList(allowed))
+			if !enumContains(field.Enum, elem) {
+				errs = append(errs, fmt.Sprintf("Frontmatter field '%s' contains %s, allowed values: %s",
+					field.Name, formatEnumValue(elem), formatEnumList(field.Enum)))
 			}
 		}
-		return ""
+		return errs
 	}
-	if !enumContains(allowed, value) {
-		return fmt.Sprintf("Frontmatter field '%s' has value %s, allowed values: %s",
-			name, formatEnumValue(value), formatEnumList(allowed))
+	if !enumContains(field.Enum, value) {
+		return []string{fmt.Sprintf("Frontmatter field '%s' has value %s, allowed values: %s",
+			field.Name, formatEnumValue(value), formatEnumList(field.Enum))}
 	}
-	return ""
+	return nil
 }
 
 func enumContains(allowed []any, value any) bool {
@@ -263,15 +281,69 @@ func enumContains(allowed []any, value any) bool {
 	return false
 }
 
-// enumEqual compares an allowed value against a frontmatter value, treating
-// numeric types (int, int64, float64) as interchangeable since YAML parsing
-// may produce any of them.
+// enumEqual compares an allowed value against a frontmatter value. Numeric
+// types (int, int64, float64) are interchangeable since YAML parsing may
+// produce any of them. Dates are compared as YYYY-MM-DD because the two sides
+// come from different decoders: schemas via yaml.v3, which resolves timestamps
+// to time.Time, and document frontmatter via goldmark-meta's yaml.v2, which
+// leaves them as strings. Maps and slices recurse so that nested dates and
+// numbers get the same treatment as top-level ones.
 func enumEqual(a, b any) bool {
 	if af, aok := toFloat(a); aok {
 		bf, bok := toFloat(b)
 		return bok && af == bf
 	}
-	return a == b
+	if ad, aok := toDateString(a); aok {
+		bd, bok := toDateString(b)
+		return bok && ad == bd
+	}
+	if am, aok := toStringMap(a); aok {
+		bm, bok := toStringMap(b)
+		if !bok || len(am) != len(bm) {
+			return false
+		}
+		for k, av := range am {
+			bv, ok := bm[k]
+			if !ok || !enumEqual(av, bv) {
+				return false
+			}
+		}
+		return true
+	}
+	if as, aok := a.([]any); aok {
+		bs, bok := b.([]any)
+		if !bok || len(as) != len(bs) {
+			return false
+		}
+		for i := range as {
+			if !enumEqual(as[i], bs[i]) {
+				return false
+			}
+		}
+		return true
+	}
+	// reflect.DeepEqual rather than ==: == panics on non-comparable dynamic
+	// types, and only scalars are guaranteed to have reached this point.
+	return reflect.DeepEqual(a, b)
+}
+
+// toStringMap normalizes either map shape a YAML decoder may produce. Nested
+// maps arrive as map[string]any from schemas (yaml.v3) but as map[any]any from
+// document frontmatter (goldmark-meta's yaml.v2), so comparing the two sides
+// directly rejects structurally identical maps on their type alone. Non-string
+// keys are rendered with %v, which is enough to compare them.
+func toStringMap(v any) (map[string]any, bool) {
+	switch m := v.(type) {
+	case map[string]any:
+		return m, true
+	case map[any]any:
+		out := make(map[string]any, len(m))
+		for k, elem := range m {
+			out[fmt.Sprintf("%v", k)] = elem
+		}
+		return out, true
+	}
+	return nil, false
 }
 
 func toFloat(v any) (float64, bool) {
@@ -286,9 +358,33 @@ func toFloat(v any) (float64, bool) {
 	return 0, false
 }
 
+// toDateString normalizes a date to YYYY-MM-DD. Timestamps carrying a clock
+// component are left alone, since mdschema's date support covers whole days
+// only and truncating them would make distinct instants compare equal.
+func toDateString(v any) (string, bool) {
+	switch d := v.(type) {
+	case time.Time:
+		if d.Hour() == 0 && d.Minute() == 0 && d.Second() == 0 && d.Nanosecond() == 0 {
+			return d.Format(dateLayout), true
+		}
+	case string:
+		if isValidDateFormat(d) {
+			return d, true
+		}
+	}
+	return "", false
+}
+
 func formatEnumValue(v any) string {
-	if s, ok := v.(string); ok {
-		return fmt.Sprintf("%q", s)
+	switch val := v.(type) {
+	case nil:
+		return "null"
+	case string:
+		return fmt.Sprintf("%q", val)
+	case time.Time:
+		if s, ok := toDateString(val); ok {
+			return s
+		}
 	}
 	return fmt.Sprintf("%v", v)
 }

--- a/internal/rules/frontmatter_test.go
+++ b/internal/rules/frontmatter_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jackchuka/mdschema/internal/parser"
 	"github.com/jackchuka/mdschema/internal/schema"
 	"github.com/jackchuka/mdschema/internal/vast"
+	"gopkg.in/yaml.v3"
 )
 
 func TestNewFrontmatterRule(t *testing.T) {
@@ -396,6 +397,160 @@ func TestFrontmatterRuleEnum(t *testing.T) {
 			}
 			if tt.wantMessage != "" && violations[0].Message != tt.wantMessage {
 				t.Errorf("Message = %q, want %q", violations[0].Message, tt.wantMessage)
+			}
+		})
+	}
+}
+
+// TestFrontmatterRuleEnumEdgeCases builds fields by unmarshalling YAML the way
+// the schema loader does, so enum entries carry the same dynamic types a real
+// schema file produces (notably time.Time for dates and []any for nested lists).
+func TestFrontmatterRuleEnumEdgeCases(t *testing.T) {
+	tests := []struct {
+		name           string
+		fieldYAML      string
+		content        string
+		wantViolations int
+		wantMessages   []string
+	}{
+		{
+			name:      "nested list element matching enum entry",
+			fieldYAML: "name: tags\ntype: array\nenum:\n  - [a, b]\n",
+			content:   "---\ntags:\n  - [a, b]\n---\n\n# Title\n",
+		},
+		{
+			name:           "nested list element not in enum",
+			fieldYAML:      "name: tags\ntype: array\nenum:\n  - [a, b]\n",
+			content:        "---\ntags:\n  - [c, d]\n---\n\n# Title\n",
+			wantViolations: 1,
+		},
+		{
+			name:      "date value in enum",
+			fieldYAML: "name: released\nformat: date\nenum: [2024-01-01, 2024-02-01]\n",
+			content:   "---\nreleased: 2024-01-01\n---\n\n# Title\n",
+		},
+		{
+			// The two decoders disagree on map key types (map[string]any from
+			// yaml.v3 vs map[any]any from goldmark-meta), so a map enum entry
+			// only matches if the comparison normalizes both sides.
+			name:      "object value matching a map enum entry",
+			fieldYAML: "name: meta\ntype: object\nenum:\n  - {a: b}\n",
+			content:   "---\nmeta:\n  a: b\n---\n\n# Title\n",
+		},
+		{
+			name:           "object value not matching a map enum entry",
+			fieldYAML:      "name: meta\ntype: object\nenum:\n  - {a: b}\n",
+			content:        "---\nmeta:\n  a: c\n---\n\n# Title\n",
+			wantViolations: 1,
+		},
+		{
+			name:      "map element inside an array enum",
+			fieldYAML: "name: items\ntype: array\nenum:\n  - {a: b}\n",
+			content:   "---\nitems:\n  - {a: b}\n---\n\n# Title\n",
+		},
+		{
+			// Nested values need the same date normalization as top-level ones.
+			name:      "date nested inside a map enum entry",
+			fieldYAML: "name: window\ntype: object\nenum:\n  - {from: 2024-01-01}\n",
+			content:   "---\nwindow:\n  from: 2024-01-01\n---\n\n# Title\n",
+		},
+		{
+			// A value that fails its type check cannot match any enum entry, so
+			// only the more specific type message should be reported.
+			name:           "type mismatch reports once, not alongside an enum violation",
+			fieldYAML:      "name: priority\ntype: number\nenum: [1, 2, 3]\n",
+			content:        "---\npriority: high\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				"Frontmatter field 'priority' should be a number",
+			},
+		},
+		{
+			name:           "format mismatch reports once, not alongside an enum violation",
+			fieldYAML:      "name: released\nformat: date\nenum: [2024-01-01]\n",
+			content:        "---\nreleased: not-a-date\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				"Frontmatter field 'released' should be in YYYY-MM-DD format",
+			},
+		},
+		{
+			name:           "date value not in enum",
+			fieldYAML:      "name: released\nformat: date\nenum: [2024-01-01, 2024-02-01]\n",
+			content:        "---\nreleased: 2024-03-01\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				`Frontmatter field 'released' has value "2024-03-01", allowed values: [2024-01-01, 2024-02-01]`,
+			},
+		},
+		{
+			name:           "scalar field rejects list value",
+			fieldYAML:      "name: status\nenum: [draft, published]\n",
+			content:        "---\nstatus:\n  - draft\n  - published\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				`Frontmatter field 'status' has value [draft published], allowed values: ["draft", "published"]`,
+			},
+		},
+		{
+			name:           "array field with scalar value defers to type check",
+			fieldYAML:      "name: tags\ntype: array\nenum: [go, cli]\n",
+			content:        "---\ntags: go\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				"Frontmatter field 'tags' should be an array",
+			},
+		},
+		{
+			name:           "null value",
+			fieldYAML:      "name: status\nenum: [draft, published]\n",
+			content:        "---\nstatus:\n---\n\n# Title\n",
+			wantViolations: 1,
+			wantMessages: []string{
+				`Frontmatter field 'status' has value null, allowed values: ["draft", "published"]`,
+			},
+		},
+		{
+			name:           "every offending array element is reported",
+			fieldYAML:      "name: tags\ntype: array\nenum: [go, cli]\n",
+			content:        "---\ntags:\n  - rust\n  - zig\n---\n\n# Title\n",
+			wantViolations: 2,
+			wantMessages: []string{
+				`Frontmatter field 'tags' contains "rust", allowed values: ["go", "cli"]`,
+				`Frontmatter field 'tags' contains "zig", allowed values: ["go", "cli"]`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var field schema.FrontmatterField
+			if err := yaml.Unmarshal([]byte(tt.fieldYAML), &field); err != nil {
+				t.Fatalf("Unmarshal() error: %v", err)
+			}
+
+			p := parser.New()
+			doc, err := p.Parse("test.md", []byte(tt.content))
+			if err != nil {
+				t.Fatalf("Parse() error: %v", err)
+			}
+
+			s := &schema.Schema{
+				Frontmatter: &schema.FrontmatterConfig{
+					Fields: []schema.FrontmatterField{field},
+				},
+			}
+
+			ctx := vast.NewContext(doc, s, "")
+			violations := NewFrontmatterRule().ValidateWithContext(ctx)
+
+			if len(violations) != tt.wantViolations {
+				t.Fatalf("Got %d violations, want %d: %v", len(violations), tt.wantViolations, violations)
+			}
+			for i, want := range tt.wantMessages {
+				if violations[i].Message != want {
+					t.Errorf("Message[%d] = %q, want %q", i, violations[i].Message, want)
+				}
 			}
 		})
 	}

--- a/internal/schema/warnings.go
+++ b/internal/schema/warnings.go
@@ -3,6 +3,7 @@ package schema
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -47,6 +48,9 @@ func walkNode(node *yaml.Node, t reflect.Type, warnings *[]Warning) {
 		if t.Kind() != reflect.Struct || opaqueTypes[t] {
 			return
 		}
+		if t == reflect.TypeOf(FrontmatterField{}) {
+			checkEnumTypes(node, warnings)
+		}
 		allowed := allowedKeys(t)
 		// Mapping content alternates key, value, key, value, ...
 		for i := 0; i+1 < len(node.Content); i += 2 {
@@ -70,6 +74,96 @@ func walkNode(node *yaml.Node, t reflect.Type, warnings *[]Warning) {
 			walkNode(child, t.Elem(), warnings)
 		}
 	}
+}
+
+var dateValueRegex = regexp.MustCompile(`^\d{4}-\d{2}-\d{2}$`)
+
+// checkEnumTypes reports enum entries that can never match the field's declared
+// type — e.g. `{type: number, enum: [low, high]}`, which rejects every possible
+// value. Array and object fields are skipped: for arrays the entries describe
+// elements rather than the field itself, and object entries have no scalar tag
+// to compare. A field with neither type nor format constrains nothing, so it is
+// skipped too.
+func checkEnumTypes(field *yaml.Node, warnings *[]Warning) {
+	var name string
+	var declared FieldType
+	var format FieldFormat
+	var enum *yaml.Node
+	for i := 0; i+1 < len(field.Content); i += 2 {
+		switch field.Content[i].Value {
+		case "name":
+			name = field.Content[i+1].Value
+		case "type":
+			declared = FieldType(field.Content[i+1].Value)
+		case "format":
+			format = FieldFormat(field.Content[i+1].Value)
+		case "enum":
+			enum = field.Content[i+1]
+		}
+	}
+	if enum == nil || enum.Kind != yaml.SequenceNode {
+		return
+	}
+	// A format implies a value type, so an enum entry can be impossible on
+	// format alone — `{format: email, enum: [1, 2]}` matches nothing.
+	if declared == "" {
+		declared = typeForFormat(format)
+	}
+
+	for _, entry := range enum.Content {
+		if enumEntryMatchesType(entry, declared) {
+			continue
+		}
+		var msg string
+		if shape := entryShape(entry); shape != "" {
+			msg = fmt.Sprintf("enum value for field %q is %s, not a %s", name, shape, declared)
+		} else {
+			msg = fmt.Sprintf("enum value %q for field %q is not a %s", entry.Value, name, declared)
+		}
+		*warnings = append(*warnings, Warning{Message: msg, Line: entry.Line})
+	}
+}
+
+// typeForFormat maps a format to the type its values must have, so enum entries
+// can be checked against `format` when `type` is omitted.
+func typeForFormat(format FieldFormat) FieldType {
+	switch format {
+	case FieldFormatDate:
+		return FieldTypeDate
+	case FieldFormatEmail, FieldFormatURL:
+		return FieldTypeString
+	}
+	return ""
+}
+
+// entryShape names a non-scalar enum entry, returning "" for scalars. Sequence
+// and mapping nodes have an empty Value, so quoting it reads as `enum value ""`.
+func entryShape(entry *yaml.Node) string {
+	switch entry.Kind {
+	case yaml.SequenceNode:
+		return "a list"
+	case yaml.MappingNode:
+		return "a mapping"
+	}
+	return ""
+}
+
+// enumEntryMatchesType compares a raw YAML node against a declared field type
+// using the tag yaml.v3 resolved for it (!!int, !!str, !!timestamp, ...).
+func enumEntryMatchesType(entry *yaml.Node, declared FieldType) bool {
+	switch declared {
+	case FieldTypeString:
+		return entry.Tag == "!!str"
+	case FieldTypeNumber:
+		return entry.Tag == "!!int" || entry.Tag == "!!float"
+	case FieldTypeBoolean:
+		return entry.Tag == "!!bool"
+	case FieldTypeDate:
+		// Quoted dates stay !!str, so accept those that look like YYYY-MM-DD.
+		return entry.Tag == "!!timestamp" ||
+			(entry.Tag == "!!str" && dateValueRegex.MatchString(entry.Value))
+	}
+	return true
 }
 
 // allowedKeys returns the yaml keys a struct type accepts, mapped to the field

--- a/internal/schema/warnings_test.go
+++ b/internal/schema/warnings_test.go
@@ -36,6 +36,137 @@ func TestUnknownKeyAtTopLevel(t *testing.T) {
 	}
 }
 
+func TestEnumTypeMismatchWarnings(t *testing.T) {
+	tests := []struct {
+		name         string
+		data         string
+		wantMessages []string
+	}{
+		{
+			name: "every bad entry is reported",
+			data: "frontmatter:\n  fields:\n    - name: priority\n      type: number\n      enum: [low, high]\n",
+			wantMessages: []string{
+				`enum value "low" for field "priority" is not a number`,
+				`enum value "high" for field "priority" is not a number`,
+			},
+		},
+		{
+			name: "one bad entry among good ones",
+			data: "frontmatter:\n  fields:\n    - name: priority\n      type: number\n      enum: [1, 2, three]\n",
+			wantMessages: []string{
+				`enum value "three" for field "priority" is not a number`,
+			},
+		},
+		{
+			name: "number under a string field",
+			data: "frontmatter:\n  fields:\n    - name: status\n      type: string\n      enum: [draft, 2]\n",
+			wantMessages: []string{
+				`enum value "2" for field "status" is not a string`,
+			},
+		},
+		{
+			name: "non-date under a date field",
+			data: "frontmatter:\n  fields:\n    - name: released\n      type: date\n      enum: [2024-01-01, soon]\n",
+			wantMessages: []string{
+				`enum value "soon" for field "released" is not a date`,
+			},
+		},
+		{
+			// Sequence and mapping nodes have an empty Value, so they are named
+			// by shape rather than quoted as an empty string.
+			name: "list entry is described by shape",
+			data: "frontmatter:\n  fields:\n    - name: status\n      type: string\n      enum:\n        - [a, b]\n",
+			wantMessages: []string{
+				`enum value for field "status" is a list, not a string`,
+			},
+		},
+		{
+			name: "mapping entry is described by shape",
+			data: "frontmatter:\n  fields:\n    - name: status\n      type: string\n      enum:\n        - {a: b}\n",
+			wantMessages: []string{
+				`enum value for field "status" is a mapping, not a string`,
+			},
+		},
+		{
+			// A format constrains the value type even with no explicit type.
+			name: "non-string under an email format",
+			data: "frontmatter:\n  fields:\n    - name: contact\n      format: email\n      enum: [1, 2]\n",
+			wantMessages: []string{
+				`enum value "1" for field "contact" is not a string`,
+				`enum value "2" for field "contact" is not a string`,
+			},
+		},
+		{
+			name: "non-date under a date format",
+			data: "frontmatter:\n  fields:\n    - name: released\n      format: date\n      enum: [2024-01-01, soon]\n",
+			wantMessages: []string{
+				`enum value "soon" for field "released" is not a date`,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings, err := checkUnknownKeys([]byte(tt.data))
+			if err != nil {
+				t.Fatalf("checkUnknownKeys() error: %v", err)
+			}
+			if len(warnings) != len(tt.wantMessages) {
+				t.Fatalf("expected %d warnings, got %d: %+v", len(tt.wantMessages), len(warnings), warnings)
+			}
+			for i, want := range tt.wantMessages {
+				if got := warnings[i].Message; got != want {
+					t.Errorf("message[%d] = %q, want %q", i, got, want)
+				}
+				if warnings[i].Line == 0 {
+					t.Errorf("warning[%d]: expected a non-zero line number", i)
+				}
+			}
+		})
+	}
+}
+
+func TestEnumTypeConsistentNoWarnings(t *testing.T) {
+	// Array fields constrain their elements, not the field itself, and
+	// untyped fields constrain nothing — neither should warn.
+	data := []byte(`frontmatter:
+  fields:
+    - name: status
+      type: string
+      enum: [draft, published]
+    - name: priority
+      type: number
+      enum: [1, 2.5]
+    - name: draft
+      type: boolean
+      enum: [true, false]
+    - name: released
+      type: date
+      enum: [2024-01-01]
+    - name: tags
+      type: array
+      enum: [go, cli]
+    - name: anything
+      enum: [1, foo, true]
+    - name: contact
+      format: email
+      enum: [user@example.com]
+    - name: homepage
+      format: url
+      enum: [https://example.com]
+    - name: shipped
+      format: date
+      enum: [2024-01-01]
+`)
+	warnings, err := checkUnknownKeys(data)
+	if err != nil {
+		t.Fatalf("error: %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("expected 0 warnings, got %+v", warnings)
+	}
+}
+
 func TestKnownKeysNoWarnings(t *testing.T) {
 	data := []byte(`structure:
   - heading:


### PR DESCRIPTION
Follow-up to #80. Four edge cases found while reviewing that feature, each with a regression test.

## Changes

**Map-valued enum entries could never match.** `enumEqual` fell through to `reflect.DeepEqual`, but the two sides decode to different map types — `map[string]any` from yaml.v3 (schema) vs `map[interface{}]interface{}` from goldmark-meta's yaml.v2 (document frontmatter). DeepEqual compares dynamic types first, so structurally identical maps always compared unequal:

```
field: {name: meta, type: object, enum: [{a: b}]}   doc: meta: {a: b}
  → VIOLATION: field 'meta' has value map[a:b], allowed values: [map[a:b]]
```

Comparison now recurses through maps and slices instead, which also normalizes nested dates and numbers the way top-level ones already were. Nested *lists* worked by luck (`[]any` on both sides), which is why the existing `enum: [[a, b]]` test didn't catch this.

**Scalar violations double-reported.** The array path already returned `nil` on a wrong-shaped value ("validateFieldType already reports the wrong shape"), but the scalar path had no equivalent guard, so `{type: number, enum: [1,2,3]}` against `priority: high` emitted both "should be a number" and an enum violation. Now gated on the type and format checks passing.

**Non-scalar enum entries produced an empty warning.** `checkEnumTypes` used `entry.Value`, which is `""` for sequence and mapping nodes, so `{type: string, enum: [[a, b]]}` warned `enum value "" for field "status" is not a string`. Now described by shape: `enum value for field "status" is a list, not a string`. Scalar messages are byte-identical to before.

**`format` wasn't considered for enum consistency.** The warning only inspected `type`, so `{format: email, enum: [1, 2]}` and `{format: date, enum: [soon]}` passed silently despite being as unsatisfiable as the `{type: number, enum: [low, high]}` case already caught. Added `typeForFormat`, used when `type` is absent, and updated the README accordingly.

## Verification

`golangci-lint`, `go test ./...`, `go vet`, `gofmt`, and the schema.json freshness check all clean. The example validates and the generate→check roundtrip is clean.

9 new regression tests. I confirmed each genuinely covers its fix by neutralizing the fixes individually and checking that exactly those 9 fail.

## Unrelated note

`golangci-lint` 2.10.1 locally reports 6 pre-existing `SA5011` nil-deref warnings in `internal/parser/paragraph_test.go` and `parser_test.go` — untouched by this PR, and main's last run was green, so it's a linter-version difference. CI pins `version: latest`, so it may surface here regardless. Separate cleanup, or pin the version.