### PR TITLE
fix(generator): resolve expr-based headings to the target filename

### DIFF
--- a/cmd/mdschema/commands/generate.go
+++ b/cmd/mdschema/commands/generate.go
@@ -56,7 +56,7 @@ func runGenerate(cfg *Config, schemaFile, outputFile string) error {
 
 	// Generate markdown content using the generator package
 	gen := generator.New()
-	content := gen.Generate(s)
+	content := gen.Generate(s, outputFile)
 
 	// Output to file or stdout
 	if outputFile != "" {

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jackchuka/mdschema/internal/rules"
 	"github.com/jackchuka/mdschema/internal/schema"
+	"github.com/jackchuka/mdschema/internal/vast"
 )
 
 // Generator creates markdown templates from schemas using rules
@@ -19,24 +20,25 @@ func New() *Generator {
 	}
 }
 
-// Generate creates a markdown template from the schema structure
-func (g *Generator) Generate(s *schema.Schema) string {
+// Generate creates a markdown template from the schema structure. outputPath (pass "" if
+// unknown) resolves an expr-based heading to its own filename instead of the expression text.
+func (g *Generator) Generate(s *schema.Schema, outputPath string) string {
 	var builder strings.Builder
 
 	// Generate frontmatter if applicable
 	g.ruleGenerator.GenerateFrontmatter(&builder, s)
 
 	for _, element := range s.Structure {
-		g.generateElement(&builder, element, 1)
+		g.generateElement(&builder, element, 1, outputPath)
 	}
 
 	return builder.String()
 }
 
 // generateElement recursively generates markdown for a structure element
-func (g *Generator) generateElement(builder *strings.Builder, element schema.StructureElement, level int) {
+func (g *Generator) generateElement(builder *strings.Builder, element schema.StructureElement, level int, outputPath string) {
 	// Generate heading - extract text from schema pattern
-	headingText := g.extractHeadingText(element.Heading.GetReadableName())
+	headingText := g.resolveHeadingText(element.Heading, outputPath, level)
 	heading := strings.Repeat("#", level) + " " + headingText
 	builder.WriteString(heading + "\n\n")
 
@@ -55,8 +57,20 @@ func (g *Generator) generateElement(builder *strings.Builder, element schema.Str
 
 	// Generate children elements
 	for _, child := range element.Children {
-		g.generateElement(builder, child, level+1)
+		g.generateElement(builder, child, level+1, outputPath)
 	}
+}
+
+// resolveHeadingText tries the filename as the heading for an expr-based pattern, keeping it
+// only if EvaluateHeadingExpr confirms the expression holds for heading == filename.
+func (g *Generator) resolveHeadingText(hp schema.HeadingPattern, outputPath string, level int) string {
+	if hp.Pattern == "" && hp.Literal == "" && hp.Expr != "" && outputPath != "" {
+		filename := vast.ExtractFilename(outputPath)
+		if matched, err := vast.EvaluateHeadingExpr(hp.Expr, filename, filename, level); err == nil && matched {
+			return filename
+		}
+	}
+	return g.extractHeadingText(hp.GetReadableName())
 }
 
 // extractHeadingText extracts human-readable text from a heading pattern

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -26,7 +26,7 @@ func TestGenerateBasicStructure(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "# Title") {
 		t.Error("Generated output should contain the heading")
@@ -42,7 +42,7 @@ func TestGenerateOptionalSection(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "Optional section") {
 		t.Error("Generated output should mark optional sections")
@@ -64,7 +64,7 @@ func TestGenerateNestedChildren(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "# Title") {
 		t.Error("Generated output should contain parent heading")
@@ -95,7 +95,7 @@ func TestGenerateWithCodeBlocks(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "```bash") {
 		t.Error("Generated output should contain bash code block")
@@ -116,7 +116,7 @@ func TestGenerateWithRequiredText(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "important text") {
 		t.Error("Generated output should mention required text")
@@ -157,7 +157,7 @@ func TestGenerateMultipleTopLevel(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if strings.Count(output, "# First") != 1 {
 		t.Error("Should generate First heading exactly once")
@@ -191,7 +191,7 @@ func TestGenerateDeeplyNested(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "# Level 1") {
 		t.Error("Should contain level 1 heading")
@@ -223,7 +223,7 @@ func TestGenerateFrontmatter(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	// Check frontmatter delimiters
 	if !strings.Contains(output, "---\n") {
@@ -269,7 +269,7 @@ func TestGenerateFrontmatterFormats(t *testing.T) {
 		Structure: []schema.StructureElement{},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "author_email: user@example.com") {
 		t.Error("Generated output should contain email format placeholder")
@@ -293,7 +293,7 @@ func TestGenerateNoFrontmatter(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	// Should not contain frontmatter delimiters when no frontmatter config
 	lines := strings.Split(output, "\n")
@@ -320,7 +320,7 @@ func TestGenerateLiteral(t *testing.T) {
 		},
 	}
 
-	output := g.Generate(s)
+	output := g.Generate(s, "")
 
 	if !strings.Contains(output, "# Title") {
 		t.Error("Generated output should contain parent heading")
@@ -340,5 +340,55 @@ func TestGenerateLiteral(t *testing.T) {
 
 	if !strings.Contains(output, "<!-- 2. ## Optional Child (optional) -->") {
 		t.Error("Generated output should contain optional child heading comment")
+	}
+}
+
+func TestGenerateExprHeading(t *testing.T) {
+	tests := []struct {
+		name       string
+		expr       string
+		outputPath string
+		want       string
+	}{
+		{"no path known, falls back to expression text", "filename == heading", "", "# filename == heading"},
+		{"equality resolved to the bare filename", "filename == heading", "moveInventoryLots", "# moveInventoryLots"},
+		{"a real path is reduced to its bare filename first", "filename == heading", "docs/command/moveInventoryLots.md", "# moveInventoryLots"},
+		{"same-transform expression also resolved", "slug(filename) == slug(heading)", "CreateOrder", "# CreateOrder"},
+		{"candidate that doesn't satisfy the expression falls back", `heading == "FixedTitle"`, "SomeOtherName", `# heading == "FixedTitle"`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := New()
+			s := &schema.Schema{
+				Structure: []schema.StructureElement{{Heading: schema.HeadingPattern{Expr: tt.expr}}},
+			}
+
+			output := g.Generate(s, tt.outputPath)
+
+			if !strings.Contains(output, tt.want) {
+				t.Errorf("Generate() = %q, want it to contain %q", output, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateFilenameDoesNotAffectLiteralOrPatternHeadings(t *testing.T) {
+	g := New()
+
+	s := &schema.Schema{
+		Structure: []schema.StructureElement{
+			{Heading: schema.HeadingPattern{Literal: "# Title"}},
+			{Heading: schema.HeadingPattern{Pattern: "# .+"}},
+		},
+	}
+
+	output := g.Generate(s, "SomeFilename")
+
+	if !strings.Contains(output, "# Title") {
+		t.Errorf("Generate() should leave a literal heading unchanged, got: %q", output)
+	}
+	if strings.Contains(output, "# SomeFilename") {
+		t.Errorf("Generate() should not substitute the filename into literal/pattern headings, got: %q", output)
 	}
 }

--- a/internal/vast/pattern.go
+++ b/internal/vast/pattern.go
@@ -52,11 +52,19 @@ func (pm *PatternMatcher) matchesHeadingExpr(heading *parser.Heading, expression
 		return false
 	}
 
-	// Build expression environment
+	matched, err := EvaluateHeadingExpr(expression, filename, heading.Text, heading.Level)
+	if err != nil {
+		return false
+	}
+	return matched
+}
+
+// EvaluateHeadingExpr evaluates a heading expression against a candidate filename/heading/level.
+func EvaluateHeadingExpr(expression, filename, heading string, level int) (bool, error) {
 	env := map[string]any{
 		"filename":    filename,
-		"heading":     heading.Text,
-		"level":       heading.Level,
+		"heading":     heading,
+		"level":       level,
 		"slug":        parser.GenerateSlug,
 		"kebab":       toKebabCase,
 		"lower":       strings.ToLower,
@@ -73,16 +81,16 @@ func (pm *PatternMatcher) matchesHeadingExpr(heading *parser.Heading, expression
 
 	program, err := expr.Compile(expression, expr.Env(env), expr.AsBool())
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	result, err := expr.Run(program, env)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	matched, ok := result.(bool)
-	return ok && matched
+	return ok && matched, nil
 }
 
 // matchRegexPattern compiles and matches a regex pattern with caching.

--- a/internal/vast/pattern_test.go
+++ b/internal/vast/pattern_test.go
@@ -1,0 +1,77 @@
+package vast
+
+import "testing"
+
+func TestEvaluateHeadingExpr(t *testing.T) {
+	tests := []struct {
+		name       string
+		expression string
+		filename   string
+		heading    string
+		level      int
+		want       bool
+	}{
+		{
+			name:       "plain equality holds when heading equals filename",
+			expression: "filename == heading",
+			filename:   "moveInventoryLots",
+			heading:    "moveInventoryLots",
+			want:       true,
+		},
+		{
+			name:       "plain equality fails when heading differs from filename",
+			expression: "filename == heading",
+			filename:   "moveInventoryLots",
+			heading:    "SomethingElse",
+			want:       false,
+		},
+		{
+			name:       "same transform on both sides holds when heading equals filename",
+			expression: "slug(filename) == slug(heading)",
+			filename:   "CreateOrder",
+			heading:    "CreateOrder",
+			want:       true,
+		},
+		{
+			name:       "same transform on both sides also holds for differently-formatted equivalents",
+			expression: "slug(filename) == slug(heading)",
+			filename:   "Create Order",
+			heading:    "create-order",
+			want:       true,
+		},
+		{
+			name:       "an expression unrelated to filename/heading equality is evaluated as-is",
+			expression: "heading == \"FixedTitle\"",
+			filename:   "anything",
+			heading:    "FixedTitle",
+			want:       true,
+		},
+		{
+			name:       "an expression unrelated to filename/heading equality correctly fails",
+			expression: "heading == \"FixedTitle\"",
+			filename:   "anything",
+			heading:    "SomethingElse",
+			want:       false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := EvaluateHeadingExpr(tt.expression, tt.filename, tt.heading, tt.level)
+			if err != nil {
+				t.Fatalf("EvaluateHeadingExpr() unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("EvaluateHeadingExpr(%q, filename=%q, heading=%q) = %v, want %v",
+					tt.expression, tt.filename, tt.heading, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvaluateHeadingExprInvalidExpression(t *testing.T) {
+	_, err := EvaluateHeadingExpr("not a valid expr (", "f", "h", 1)
+	if err == nil {
+		t.Error("EvaluateHeadingExpr() expected an error for an invalid expression, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

- `generate` scaffolds an expr-based heading (e.g. `filename == heading`) as that literal expression text, since the generator doesn't know the target filename — the file then fails its own `check`.
- Now tries the filename itself as the heading, verifies it against the real expression (`vast.EvaluateHeadingExpr`), and only falls back to the old text if that candidate doesn't actually satisfy it.

```
$ mdschema generate --schema schema.yml --output CreateOrder.md
$ head -1 CreateOrder.md
# filename == heading      # before
# CreateOrder              # after
```