### PR TITLE
fix(generator): let expr win over pattern and guard empty filenames

### DIFF
--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -64,10 +64,13 @@ func (g *Generator) generateElement(builder *strings.Builder, element schema.Str
 // resolveHeadingText tries the filename as the heading for an expr-based pattern, keeping it
 // only if EvaluateHeadingExpr confirms the expression holds for heading == filename.
 func (g *Generator) resolveHeadingText(hp schema.HeadingPattern, outputPath string, level int) string {
-	if hp.Pattern == "" && hp.Literal == "" && hp.Expr != "" && outputPath != "" {
+	// Mirror PatternMatcher.MatchesHeading: expr wins over pattern/literal when both are set.
+	if hp.Expr != "" && outputPath != "" {
 		filename := vast.ExtractFilename(outputPath)
-		if matched, err := vast.EvaluateHeadingExpr(hp.Expr, filename, filename, level); err == nil && matched {
-			return filename
+		if filename != "" {
+			if matched, err := vast.EvaluateHeadingExpr(hp.Expr, filename, filename, level); err == nil && matched {
+				return filename
+			}
 		}
 	}
 	return g.extractHeadingText(hp.GetReadableName())

--- a/internal/generator/generator_test.go
+++ b/internal/generator/generator_test.go
@@ -355,6 +355,7 @@ func TestGenerateExprHeading(t *testing.T) {
 		{"a real path is reduced to its bare filename first", "filename == heading", "docs/command/moveInventoryLots.md", "# moveInventoryLots"},
 		{"same-transform expression also resolved", "slug(filename) == slug(heading)", "CreateOrder", "# CreateOrder"},
 		{"candidate that doesn't satisfy the expression falls back", `heading == "FixedTitle"`, "SomeOtherName", `# heading == "FixedTitle"`},
+		{"path with no name before the extension falls back", "filename == heading", "docs/.md", "# filename == heading"},
 	}
 
 	for _, tt := range tests {
@@ -370,6 +371,23 @@ func TestGenerateExprHeading(t *testing.T) {
 				t.Errorf("Generate() = %q, want it to contain %q", output, tt.want)
 			}
 		})
+	}
+}
+
+func TestGenerateExprWinsOverPatternAndLiteral(t *testing.T) {
+	g := New()
+
+	s := &schema.Schema{
+		Structure: []schema.StructureElement{
+			{Heading: schema.HeadingPattern{Pattern: "^# .+$", Expr: "filename == heading"}},
+			{Heading: schema.HeadingPattern{Literal: "# Title", Expr: "filename == heading"}},
+		},
+	}
+
+	output := g.Generate(s, "docs/CreateOrder.md")
+
+	if strings.Count(output, "# CreateOrder") != 2 {
+		t.Errorf("Generate() should let expr win over pattern/literal, got: %q", output)
 	}
 }
 


### PR DESCRIPTION
Follow-up to #84 — two cases where `generate` still emits a file that fails its own `check`.

## 1. Inverted precedence vs. the matcher

`resolveHeadingText` resolved the filename only when `Pattern == "" && Literal == "" && Expr != ""`, but `vast.PatternMatcher.MatchesHeading` checks `Expr` **first** and ignores `Pattern`/`Literal` when it is set. Nothing rejects a heading carrying both keys, so:

```yaml
structure:
  - heading:
      pattern: "^# .+$"
      expr: "filename == heading"
```

```
$ mdschema generate s.yml -o out/Bar.md
$ head -1 out/Bar.md
# ^# .+$
$ mdschema check --schema s.yml out/Bar.md
✗ 1:3 [structure] Heading "# ^# .+$" does not match expression "filename == heading"
```

Now gated on `hp.Expr != "" && outputPath != ""`, mirroring `MatchesHeading`. Output is `# Bar`, check passes.

## 2. Missing `filename == ""` guard

`matchesHeadingExpr` returns early when the extracted filename is empty; `resolveHeadingText` did not. For an output path whose base is only an extension (`-o out/.md`), `filename == heading` evaluated `"" == ""` → true and a bare `# ` heading was written — one that check time, with the guard in place, can never accept. The generator now falls back to the expression text for that case.

## Tests

- `docs/.md` row added to `TestGenerateExprHeading`
- new `TestGenerateExprWinsOverPatternAndLiteral`

`go build ./...` and `go test ./...` pass.